### PR TITLE
Add some load timings to the report

### DIFF
--- a/debug-report.js
+++ b/debug-report.js
@@ -1,7 +1,10 @@
 /**
  * Registers the report on chatmessage
  */
+const timings = { init: 0, setup: 0, ready: 0, canvas_init: 0, canvas_ready: 0 }
+
 Hooks.once('init', () => {
+    timings.init = performance.now();
     console.log("Debug Report Loaded: Use /debug in chat window to create a report");
 });
 
@@ -36,6 +39,19 @@ Hooks.once('ready', () => {
     }
 
 });
+
+Hooks.once('setup', () => {
+  timings.setup = performance.now();
+});
+
+Hooks.once('canvasInit', () => {
+  timings.canvas_init = performance.now();
+});
+
+Hooks.once('canvasReady', () => {
+  timings.canvas_ready = performance.now();
+});
+
 
 Hooks.once("renderSettings", (app, html) => {
   const newHead = document.querySelector("#settings").appendChild(document.createElement("h2"))
@@ -165,7 +181,14 @@ function GenerateReport() {
         report.Active_Modules[m.data.name] = `${m.data.title} v${m.data.version}`;
       } 
     });
-    
+
+    report.Timings_From_Module_Init = {
+      Setup: (timings.setup - timings.init) / 1000,
+      Ready: (timings.ready - timings.init) / 1000,
+      Canvas_Init: (timings.canvas_init - timings.init) / 1000,
+      Canvas_Ready: (timings.canvas_ready - timings.init) / 1000
+    }
+
     for (const [k1, v1] of Object.entries(report)) {
       output += `${k1}:\n`;
       for (const [k2, v2] of Object.entries(v1)) {


### PR DESCRIPTION
Thought it might be useful for some to get a rough estimate of load times. (It is something I and my players notice, for sure.) For simplicity, I just added measurements from the init hook for this module to later hooks, such as ready and canvas ready. Pretty basics, really, but still possibly useful.

This of course, does not reflect the total time until Foundry is loaded. To get a better sense of the total load time, you would need to find a way to know when the user in fact started the log in. You could get closer by renaming this module to something like _debug-report, to get to the init hook faster, and marking it as a library module, which I think load first. Or maybe you or someone else knows how to get the load start time from Foundry API.

Edit: Actually, I stumbled across [this webdoc](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_nodetiming), which suggests that `performance.now` starts at 0 when the node process starts. So that would be a pretty good indicator of when the log-in occurred. In that case, you can simply set up the report like this:

 ```js
   report.Timings = {
      Init: timings.init / 1000,
      Setup: timings.setup / 1000,
      Ready: timings.ready / 1000,
      Canvas_Init: timings.canvas_init / 1000,
      Canvas_Ready: timings.canvas_ready / 1000
    }
```